### PR TITLE
Added Getters for Freecam Position as Vec3 and as BlockPos

### DIFF
--- a/common/mod/java/com/zergatul/freecam/FreeCam.java
+++ b/common/mod/java/com/zergatul/freecam/FreeCam.java
@@ -86,6 +86,14 @@ public class FreeCam {
         return yRot;
     }
 
+    public Vec3 getPos() {
+        return new Vec3(x, y, z);
+    }
+
+    public BlockPos getBlockPos() {
+        return new BlockPos((int) x, (int) y, (int) z);
+    }
+
     public FreeCamConfig getConfig() {
         return config;
     }


### PR DESCRIPTION
Hey I got a Little Change which makes it a bit easier to get the Position of the Freecam when Hooking in to the Freecam Mod.

**What's new?**:
You can now use `Freecam.getPos()` to get the Freecam Position as Vec3/Vec3d and the BlockPos equivalent with `Freecam.getBlockPos()`.

